### PR TITLE
Fix variable name in mc.py

### DIFF
--- a/mastercurves/mc.py
+++ b/mastercurves/mc.py
@@ -232,7 +232,7 @@ class MasterCurve:
         if vtransform.type == "Multiply":
             self.vparam_names += ["b"]
         else:
-            self.vparam_names += [transform.param]
+            self.vparam_names += [vtransform.param]
         self.vparams += [vtransform.default]
         self.vuncertainties += [0.0]
         self.vbounds += [vtransform.bounds]


### PR DESCRIPTION
It seems as there is a typo in a variable name in a method in `mc.py`.